### PR TITLE
Changed snapshots hands-on session key 

### DIFF
--- a/_keys/3_snapshots/hands-on-1.sql
+++ b/_keys/3_snapshots/hands-on-1.sql
@@ -3,10 +3,10 @@ your file products_snapshot.sql. Add the necessary Snapshot fields to the file.
 ***For the target_schema, updated it with "snapshots_(your dbt username)"
 
 --------
--- file: snapshots/products_snapshots.sql
+-- file: snapshots/products_snapshot.sql
 --------
 
-{% snapshot product_snapshot %}
+{% snapshot products_snapshot %}
 {{
   config(
     target_database='advanced_materializations',


### PR DESCRIPTION
Changed snapshots hands-on session key to say products_snapshot in the snapshot name since that's the ref we use to call the table. {{ ref('products_snapshot') }}